### PR TITLE
VKUser.lists is array of integers, not String

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/api/model/VKUser.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/api/model/VKUser.java
@@ -44,7 +44,7 @@ public class VKUser extends VKApiModel {
     public String photo_max_orig;
     public long online;
     public long online_mobile;
-    public String lists;
+    public List<Integer> lists;
     public String domain;
     public long has_mobile;
     public Map<String,String> contacts;


### PR DESCRIPTION
This change fixes the exceptions when parsing VkUser fields.

```
W/System.err(4919): java.lang.ClassCastException: org.json.JSONArray cannot be cast to java.lang.Number
```

VkUser.lists returned from server is JSONArray of integers, not String or something else.
