### PR TITLE
Fill "fields" property with JSON values when parsing

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/api/model/VKApiOwner.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/api/model/VKApiOwner.java
@@ -56,6 +56,7 @@ public class VKApiOwner extends VKApiModel implements Identifiable, android.os.P
      * Fills an owner from JSONObject
      */
     public VKApiOwner parse(JSONObject from) {
+        fields = from;
         id = from.optInt("id");
         return this;
     }


### PR DESCRIPTION
Sometime it's necessary to have an access to some fields that come from server but corresponding entity does not have these properties.
