### PR TITLE
Fix build with new Android Support Repository

### DIFF
--- a/vksdk_library/build.gradle
+++ b/vksdk_library/build.gradle
@@ -28,7 +28,7 @@ configurations {
 }
 
 dependencies {
-    externalCompile 'com.android.support:support-v4:+'
+    externalCompile 'com.android.support:support-v4:19.1.+'
 
     javadoc 'org.apache.httpcomponents:httpclient:4.0.1'
     javadoc 'org.json:json:20080701'


### PR DESCRIPTION
If you do not specify the version, an error occurs with new version of Android Support Repository (because last version of support library only for L preview):

> Manifest merger failed : uses-sdk:minSdkVersion 14 cannot be smaller than version L declared in library com.android.support:support-v4:21.0.0-rc1
