### PR TITLE
Remove "final" for VK_SDK_REQUEST_CODE

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
@@ -49,7 +49,7 @@ public class VKSdk {
     /**
      * Start SDK activity for result with that request code
      */
-    public static final int VK_SDK_REQUEST_CODE = 0xf228;
+    public static int VK_SDK_REQUEST_CODE = 0xf228;
 
     /**
      * Instance of SDK


### PR DESCRIPTION
VK_SDK_REQUEST_CODE must be editable so one can properly register OnActivityResultHandler, which uses a generated request code.
This is required for integration with Corona SDK Enterprise framework, in which you can't override onActivityResult()

Example of usage:
```java
int requestCode = activity.registerActivityResultHandler(new ResultHandler());
VKSdk.VK_SDK_REQUEST_CODE = requestCode;
VKSdk.authorize(permissions, revokeAccess, forceOAuth);
```