### PR TITLE
Some Bug Fix and SDK Improvement

### DIFF
--- a/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivity.java
+++ b/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivity.java
@@ -179,6 +179,11 @@ public class TestActivity extends ActionBarActivity {
                                 public void onVkShareCancel() {
                                     b.recycle();
                                 }
+
+                                @Override
+                                public void onVkShareError(VKError error) {
+                                    b.recycle();
+                                }
                             })
                             .show(getFragmentManager(), "VK_SHARE_DIALOG");
                 }

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
@@ -22,7 +22,6 @@
 package com.vk.sdk.dialogs;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -38,7 +37,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
 import android.view.Display;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -331,6 +329,9 @@ public class VKShareDialog extends DialogFragment {
                 if (VKSdk.DEBUG) {
                     Log.w(VKSdk.SDK_TAG, "Cannot load photos for share: " + error.toString());
                 }
+                if (mListener != null) {
+                    mListener.onVkShareError(error);
+                }
             }
         });
     }
@@ -400,6 +401,9 @@ public class VKShareDialog extends DialogFragment {
             @Override
             public void onError(VKError error) {
                 setIsLoading(false);
+                if (mListener != null) {
+                    mListener.onVkShareError(error);
+                }
             }
 
             @Override
@@ -432,6 +436,9 @@ public class VKShareDialog extends DialogFragment {
                     @Override
                     public void onError(VKError error) {
                         setIsLoading(false);
+                        if (mListener != null) {
+                            mListener.onVkShareError(error);
+                        }
                     }
                 });
             } else {
@@ -487,5 +494,7 @@ public class VKShareDialog extends DialogFragment {
         void onVkShareComplete(int postId);
 
         void onVkShareCancel();
+
+        void onVkShareError(VKError error);
     }
 }

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
@@ -246,7 +246,7 @@ public class VKShareDialog extends DialogFragment {
                 if (mListener != null) {
                     mListener.onVkShareCancel();
                 }
-                VKShareDialog.this.dismiss();
+                dismissAllowingStateLoss();
             }
         });
 
@@ -409,7 +409,7 @@ public class VKShareDialog extends DialogFragment {
                 if (mListener != null) {
                     mListener.onVkShareComplete(res.post_id);
                 }
-                dismiss();
+                dismissAllowingStateLoss();
             }
         });
     }


### PR DESCRIPTION
**Fix a crash issue on share dialog**

This crash issue will happen if you receive a phone call or press Home button while you are sharing with VkSdk (after you press "send" but before it completes). This happened a lot in my app.

**Added an API to expose share error to VKShareDialogListener**

This will allow developers to display proper error messages to end-user.

Some unused imports are removed.