### PR TITLE
Prevent NPE if data is null.

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
@@ -259,7 +259,7 @@ public class VKSdk {
             if (resultCode == VKSdk.RESULT_OK) {
                 vkCallback.onResult(VKAccessToken.currentToken());
             } else if (resultCode == VKSdk.RESULT_ERROR) {
-                vkCallback.onError((VKError) VKObject.getRegisteredObject(data.getLongExtra(VKSdk.EXTRA_ERROR_ID, 0)));
+                vkCallback.onError((VKError) VKObject.getRegisteredObject(data == null ? 0 : data.getLongExtra(VKSdk.EXTRA_ERROR_ID, 0)));
             }
             return true;
         } else {


### PR DESCRIPTION
VkServiceActivity in onActivityResult() can set result to RESULT_ERROR without any data. This leads to NPE in VkSdk's onActivityResult().