### PR TITLE
Making VKShare work on native ICS activities

### DIFF
--- a/VKTestApplication/src/main/AndroidManifest.xml
+++ b/VKTestApplication/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".TestActivity" />
+        <activity android:name=".TestActivityCompat" />
+        <activity android:name=".TestActivityICS" />
         <activity android:name=".ApiCallActivity" />
 
     </application>

--- a/VKTestApplication/src/main/java/com/vk/vktestapp/LoginActivity.java
+++ b/VKTestApplication/src/main/java/com/vk/vktestapp/LoginActivity.java
@@ -1,6 +1,7 @@
 package com.vk.vktestapp;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.view.LayoutInflater;
@@ -126,7 +127,11 @@ public class LoginActivity extends FragmentActivity {
     }
 
     private void startTestActivity() {
-        startActivity(new Intent(this, TestActivity.class));
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES. ICE_CREAM_SANDWICH) {
+            startActivity(new Intent(this, TestActivityICS.class));
+        } else {
+            startActivity(new Intent(this, TestActivityCompat.class));
+        }
     }
 
     public static class LoginFragment extends android.support.v4.app.Fragment {

--- a/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivityCompat.java
+++ b/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivityCompat.java
@@ -1,0 +1,356 @@
+package com.vk.vktestapp;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AlertDialog;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.vk.sdk.VKSdk;
+import com.vk.sdk.api.VKApi;
+import com.vk.sdk.api.VKApiConst;
+import com.vk.sdk.api.VKBatchRequest;
+import com.vk.sdk.api.VKBatchRequest.VKBatchRequestListener;
+import com.vk.sdk.api.VKError;
+import com.vk.sdk.api.VKParameters;
+import com.vk.sdk.api.VKRequest;
+import com.vk.sdk.api.VKRequest.VKRequestListener;
+import com.vk.sdk.api.VKResponse;
+import com.vk.sdk.api.methods.VKApiCaptcha;
+import com.vk.sdk.api.model.VKApiPhoto;
+import com.vk.sdk.api.model.VKApiUser;
+import com.vk.sdk.api.model.VKAttachments;
+import com.vk.sdk.api.model.VKPhotoArray;
+import com.vk.sdk.api.model.VKWallPostResult;
+import com.vk.sdk.api.photo.VKImageParameters;
+import com.vk.sdk.api.photo.VKUploadImage;
+import com.vk.sdk.dialogs.VKShareDialog;
+import com.vk.sdk.dialogs.VKShareDialogCompat;
+import com.vk.sdk.payments.VKPaymentsCallback;
+
+import org.json.JSONArray;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TestActivityCompat extends ActionBarActivity {
+
+    private static final int[] IDS = {R.id.users_get, R.id.friends_get, R.id.messages_get, R.id.dialogs_get,
+            R.id.captcha_force, R.id.upload_photo, R.id.wall_post, R.id.wall_getById, R.id.test_validation,
+            R.id.test_share, R.id.upload_photo_to_wall, R.id.upload_doc, R.id.upload_several_photos_to_wall,
+            R.id.test_send_request};
+
+    public static final int TARGET_GROUP = 60479154;
+    public static final int TARGET_ALBUM = 181808365;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test);
+        VKSdk.requestUserState(this, new VKPaymentsCallback() {
+            @Override
+            public void onUserState(final boolean userIsVk) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+//						Toast.makeText(TestActivityCompat.this, userIsVk ? "user is vk's" : "user is not vk's", Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+        });
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction().add(R.id.container, new PlaceholderFragment()).commit();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * A placeholder fragment containing a simple view.
+     */
+    public static class PlaceholderFragment extends Fragment implements View.OnClickListener {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            View view = inflater.inflate(R.layout.fragment_test, container, false);
+            for (int id : IDS) {
+                view.findViewById(id).setOnClickListener(this);
+            }
+            return view;
+        }
+
+        @Override
+        public void onClick(View v) {
+            switch (v.getId()) {
+                case R.id.test_send_request: {
+                    makeRequest();
+                }
+                break;
+                case R.id.users_get: {
+                    VKRequest request = VKApi.users().get(VKParameters.from(VKApiConst.FIELDS,
+                            "id,first_name,last_name,sex,bdate,city,country,photo_50,photo_100," +
+                                    "photo_200_orig,photo_200,photo_400_orig,photo_max,photo_max_orig,online," +
+                                    "online_mobile,lists,domain,has_mobile,contacts,connections,site,education," +
+                                    "universities,schools,can_post,can_see_all_posts,can_see_audio,can_write_private_message," +
+                                    "status,last_seen,common_count,relation,relatives,counters"));
+                    request.secure = false;
+                    request.useSystemLanguage = false;
+                    startApiCall(request);
+                }
+                break;
+                case R.id.friends_get:
+                    startApiCall(VKApi.friends().get(VKParameters.from(VKApiConst.FIELDS, "id,first_name,last_name,sex,bdate,city")));
+                    break;
+                case R.id.messages_get:
+                    startApiCall(VKApi.messages().get());
+                    break;
+                case R.id.dialogs_get:
+                    startApiCall(VKApi.messages().getDialogs());
+                    break;
+                case R.id.captcha_force:
+                    startApiCall(new VKApiCaptcha().force());
+                    break;
+                case R.id.upload_photo: {
+                    final Bitmap photo = getPhoto();
+                    VKRequest request = VKApi.uploadAlbumPhotoRequest(new VKUploadImage(photo, VKImageParameters.pngImage()), TARGET_ALBUM, TARGET_GROUP);
+                    request.executeWithListener(new VKRequestListener() {
+                        @Override
+                        public void onComplete(VKResponse response) {
+                            recycleBitmap(photo);
+                            VKPhotoArray photoArray = (VKPhotoArray) response.parsedModel;
+                            Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(String.format("https://vk.com/photo-%d_%s", TARGET_GROUP, photoArray.get(0).id)));
+                            startActivity(i);
+                        }
+
+                        @Override
+                        public void onError(VKError error) {
+                            showError(error);
+                        }
+                    });
+                }
+                break;
+                case R.id.wall_post:
+                    makePost(null, "Hello, friends!");
+                    break;
+                case R.id.wall_getById:
+                    startApiCall(VKApi.wall().getById(VKParameters.from(VKApiConst.POSTS, "1_45558")));
+                    break;
+                case R.id.test_validation:
+                    startApiCall(new VKRequest("account.testValidation"));
+                    break;
+                case R.id.test_share: {
+                    final Bitmap b = getPhoto();
+                    VKPhotoArray photos = new VKPhotoArray();
+                    photos.add(new VKApiPhoto("photo-47200925_314622346"));
+                    new VKShareDialog()
+                            .setText("I created this post with VK Android SDK\nSee additional information below\n#vksdk")
+                            .setUploadedPhotos(photos)
+                            .setAttachmentImages(new VKUploadImage[]{
+                                    new VKUploadImage(b, VKImageParameters.pngImage())
+                            })
+                            .setAttachmentLink("VK Android SDK information", "https://vk.com/dev/android_sdk")
+                            .setShareDialogListener(new VKShareDialog.VKShareDialogListener() {
+                                @Override
+                                public void onVkShareComplete(int postId) {
+                                    recycleBitmap(b);
+                                }
+
+                                @Override
+                                public void onVkShareCancel() {
+                                    recycleBitmap(b);
+                                }
+
+                                @Override
+                                public void onVkShareError(VKError error) {
+                                    recycleBitmap(b);
+                                }
+                            })
+                            .show(getActivity().getSupportFragmentManager(), "VK_SHARE_DIALOG");
+                }
+                break;
+                case R.id.upload_photo_to_wall: {
+                    final Bitmap photo = getPhoto();
+                    VKRequest request = VKApi.uploadWallPhotoRequest(new VKUploadImage(photo, VKImageParameters.jpgImage(0.9f)), 0, TARGET_GROUP);
+                    request.executeWithListener(new VKRequestListener() {
+                        @Override
+                        public void onComplete(VKResponse response) {
+                            recycleBitmap(photo);
+                            VKApiPhoto photoModel = ((VKPhotoArray) response.parsedModel).get(0);
+                            makePost(new VKAttachments(photoModel));
+                        }
+
+                        @Override
+                        public void onError(VKError error) {
+                            showError(error);
+                        }
+                    });
+                }
+                break;
+                case R.id.upload_doc:
+                    startApiCall(VKApi.docs().uploadDocRequest(getFile()));
+                    break;
+                case R.id.upload_several_photos_to_wall: {
+                    final Bitmap photo = getPhoto();
+                    VKRequest request1 = VKApi.uploadWallPhotoRequest(new VKUploadImage(photo, VKImageParameters.jpgImage(0.9f)), 0, TARGET_GROUP);
+                    VKRequest request2 = VKApi.uploadWallPhotoRequest(new VKUploadImage(photo, VKImageParameters.jpgImage(0.5f)), 0, TARGET_GROUP);
+                    VKRequest request3 = VKApi.uploadWallPhotoRequest(new VKUploadImage(photo, VKImageParameters.jpgImage(0.1f)), 0, TARGET_GROUP);
+                    VKRequest request4 = VKApi.uploadWallPhotoRequest(new VKUploadImage(photo, VKImageParameters.pngImage()), 0, TARGET_GROUP);
+
+                    VKBatchRequest batch = new VKBatchRequest(request1, request2, request3, request4);
+                    batch.executeWithListener(new VKBatchRequestListener() {
+                        @Override
+                        public void onComplete(VKResponse[] responses) {
+                            super.onComplete(responses);
+                            recycleBitmap(photo);
+                            VKAttachments attachments = new VKAttachments();
+                            for (VKResponse response : responses) {
+                                VKApiPhoto photoModel = ((VKPhotoArray) response.parsedModel).get(0);
+                                attachments.add(photoModel);
+                            }
+                            makePost(attachments);
+                        }
+
+                        @Override
+                        public void onError(VKError error) {
+                            showError(error);
+                        }
+                    });
+                }
+                break;
+            }
+        }
+
+        private void startApiCall(VKRequest request) {
+            Intent i = new Intent(getActivity(), ApiCallActivity.class);
+            i.putExtra("request", request.registerObject());
+            startActivity(i);
+        }
+
+        private void showError(VKError error) {
+            new AlertDialog.Builder(getActivity())
+                    .setMessage(error.toString())
+                    .setPositiveButton("OK", null)
+                    .show();
+            if (error.httpError != null) {
+                Log.w("Test", "Error in request or upload", error.httpError);
+            }
+        }
+
+        private Bitmap getPhoto() {
+            try {
+                return BitmapFactory.decodeStream(getActivity().getAssets().open("android.jpg"));
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+
+        private static void recycleBitmap(@Nullable final Bitmap bitmap) {
+            if (bitmap != null) {
+                bitmap.recycle();
+            }
+        }
+
+        private File getFile() {
+            try {
+                InputStream inputStream = getActivity().getAssets().open("android.jpg");
+                File file = new File(getActivity().getCacheDir(), "android.jpg");
+                OutputStream output = new FileOutputStream(file);
+                byte[] buffer = new byte[4 * 1024]; // or other buffer size
+                int read;
+
+                while ((read = inputStream.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+                output.flush();
+                output.close();
+                return file;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+        private void makePost(VKAttachments attachments) {
+            makePost(attachments, null);
+        }
+
+        private void makeRequest() {
+            VKRequest request = new VKRequest("apps.getFriendsList", VKParameters.from("extended", 1, "type", "request"));
+            request.executeWithListener(new VKRequestListener() {
+                @Override
+                public void onComplete(VKResponse response) {
+                    final Context context = getContext();
+                    if (context == null || !isAdded()) {
+                        return;
+                    }
+                    try {
+                        JSONArray jsonArray = response.json.getJSONObject("response").getJSONArray("items");
+                        int length = jsonArray.length();
+                        final VKApiUser[] vkApiUsers = new VKApiUser[length];
+                        CharSequence[] vkApiUsersNames = new CharSequence[length];
+                        for (int i = 0; i < length; i++) {
+                            VKApiUser user = new VKApiUser(jsonArray.getJSONObject(i));
+                            vkApiUsers[i] = user;
+                            vkApiUsersNames[i] = user.first_name + " " + user.last_name;
+                        }
+                        new AlertDialog.Builder(context)
+                                .setTitle(R.string.send_request_title)
+                                .setItems(vkApiUsersNames, new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        startApiCall(new VKRequest("apps.sendRequest",
+                                                VKParameters.from("user_id", vkApiUsers[which].id, "type", "request")));
+                                    }
+                                }).create().show();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+        }
+
+        private void makePost(VKAttachments attachments, String message) {
+            VKRequest post = VKApi.wall().post(VKParameters.from(VKApiConst.OWNER_ID, "-" + TARGET_GROUP, VKApiConst.ATTACHMENTS, attachments, VKApiConst.MESSAGE, message));
+            post.setModelClass(VKWallPostResult.class);
+            post.executeWithListener(new VKRequestListener() {
+                @Override
+                public void onComplete(VKResponse response) {
+                    if (isAdded()) {
+                        VKWallPostResult result = (VKWallPostResult) response.parsedModel;
+                        Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(String.format("https://vk.com/wall-%d_%s", TARGET_GROUP, result.post_id)));
+                        startActivity(i);
+                    }
+                }
+
+                @Override
+                public void onError(VKError error) {
+                    showError(error.apiError != null ? error.apiError : error);
+                }
+            });
+        }
+    }
+}

--- a/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivityICS.java
+++ b/VKTestApplication/src/main/java/com/vk/vktestapp/TestActivityICS.java
@@ -1,15 +1,17 @@
 package com.vk.vktestapp;
 
+import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.ActionBarActivity;
+import android.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -37,6 +39,7 @@ import com.vk.sdk.api.model.VKWallPostResult;
 import com.vk.sdk.api.photo.VKImageParameters;
 import com.vk.sdk.api.photo.VKUploadImage;
 import com.vk.sdk.dialogs.VKShareDialog;
+import com.vk.sdk.dialogs.VKShareDialogCompat;
 import com.vk.sdk.payments.VKPaymentsCallback;
 
 import org.json.JSONArray;
@@ -47,7 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class TestActivity extends ActionBarActivity {
+public class TestActivityICS extends Activity {
 
 	private static final int[] IDS = {R.id.users_get, R.id.friends_get, R.id.messages_get, R.id.dialogs_get,
 			R.id.captcha_force, R.id.upload_photo, R.id.wall_post, R.id.wall_getById, R.id.test_validation,
@@ -57,6 +60,7 @@ public class TestActivity extends ActionBarActivity {
 	public static final int TARGET_GROUP = 60479154;
 	public static final int TARGET_ALBUM = 181808365;
 
+	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -67,16 +71,16 @@ public class TestActivity extends ActionBarActivity {
 				runOnUiThread(new Runnable() {
 					@Override
 					public void run() {
-//						Toast.makeText(TestActivity.this, userIsVk ? "user is vk's" : "user is not vk's", Toast.LENGTH_SHORT).show();
+//						Toast.makeText(TestActivityCompat.this, userIsVk ? "user is vk's" : "user is not vk's", Toast.LENGTH_SHORT).show();
 					}
 				});
 			}
 		});
-		if (getSupportActionBar() != null) {
-			getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+		if (getActionBar() != null) {
+			getActionBar().setDisplayHomeAsUpEnabled(true);
 		}
 		if (savedInstanceState == null) {
-			getSupportFragmentManager().beginTransaction().add(R.id.container, new PlaceholderFragment()).commit();
+			getFragmentManager().beginTransaction().add(R.id.container, new PlaceholderFragment()).commit();
 		}
 	}
 
@@ -92,6 +96,7 @@ public class TestActivity extends ActionBarActivity {
 	/**
 	 * A placeholder fragment containing a simple view.
 	 */
+	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 	public static class PlaceholderFragment extends Fragment implements View.OnClickListener {
 		@Override
 		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -102,6 +107,7 @@ public class TestActivity extends ActionBarActivity {
 			return view;
 		}
 
+		@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 		@Override
 		public void onClick(View v) {
 			switch (v.getId()) {
@@ -243,12 +249,14 @@ public class TestActivity extends ActionBarActivity {
 			}
 		}
 
+		@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 		private void startApiCall(VKRequest request) {
 			Intent i = new Intent(getActivity(), ApiCallActivity.class);
 			i.putExtra("request", request.registerObject());
 			startActivity(i);
 		}
 
+		@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 		private void showError(VKError error) {
 			new AlertDialog.Builder(getActivity())
 					.setMessage(error.toString())
@@ -259,6 +267,7 @@ public class TestActivity extends ActionBarActivity {
 			}
 		}
 
+		@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 		private Bitmap getPhoto() {
 			try {
 				return BitmapFactory.decodeStream(getActivity().getAssets().open("android.jpg"));
@@ -274,6 +283,7 @@ public class TestActivity extends ActionBarActivity {
 			}
 		}
 
+		@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 		private File getFile() {
 			try {
 				InputStream inputStream = getActivity().getAssets().open("android.jpg");
@@ -301,9 +311,10 @@ public class TestActivity extends ActionBarActivity {
 		private void makeRequest() {
 			VKRequest request = new VKRequest("apps.getFriendsList", VKParameters.from("extended", 1, "type", "request"));
 			request.executeWithListener(new VKRequestListener() {
+				@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 				@Override
 				public void onComplete(VKResponse response) {
-					final Context context = getContext();
+					final Context context = getActivity();
 					if (context == null || !isAdded()) {
 						return;
 					}
@@ -337,6 +348,7 @@ public class TestActivity extends ActionBarActivity {
 			VKRequest post = VKApi.wall().post(VKParameters.from(VKApiConst.OWNER_ID, "-" + TARGET_GROUP, VKApiConst.ATTACHMENTS, attachments, VKApiConst.MESSAGE, message));
 			post.setModelClass(VKWallPostResult.class);
 			post.executeWithListener(new VKRequestListener() {
+				@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 				@Override
 				public void onComplete(VKResponse response) {
 					if (isAdded()) {

--- a/VKTestApplication/src/main/res/layout/activity_test.xml
+++ b/VKTestApplication/src/main/res/layout/activity_test.xml
@@ -3,5 +3,5 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".TestActivity"
+    tools:context=".TestActivityCompat"
     tools:ignore="MergeRootFrame" />

--- a/VKTestApplication/src/main/res/layout/fragment_test.xml
+++ b/VKTestApplication/src/main/res/layout/fragment_test.xml
@@ -2,7 +2,7 @@
             xmlns:tools="http://schemas.android.com/tools"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:context=".TestActivity$PlaceholderFragment">
+            tools:context=".TestActivityCompat$PlaceholderFragment">
 
     <LinearLayout style="@style/Container">
 

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialog.java
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2014 VK.com
+//  Copyright (c) 2015 VK.com
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of
 //  this software and associated documentation files (the "Software"), to deal in
@@ -21,56 +21,11 @@
 
 package com.vk.sdk.dialogs;
 
-import android.annotation.SuppressLint;
-import android.app.Dialog;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.graphics.Bitmap;
-import android.graphics.Point;
 import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
-import android.os.Parcel;
-import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
-import android.util.Log;
-import android.view.Display;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.Window;
-import android.view.WindowManager;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.HorizontalScrollView;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
-import com.vk.sdk.R;
-import com.vk.sdk.VKSdk;
-import com.vk.sdk.VKUIHelper;
-import com.vk.sdk.api.VKApi;
-import com.vk.sdk.api.VKApiConst;
 import com.vk.sdk.api.VKError;
-import com.vk.sdk.api.VKParameters;
-import com.vk.sdk.api.VKRequest;
-import com.vk.sdk.api.VKResponse;
-import com.vk.sdk.api.httpClient.VKHttpClient;
-import com.vk.sdk.api.httpClient.VKImageOperation;
-import com.vk.sdk.api.model.VKApiLink;
-import com.vk.sdk.api.model.VKApiPhoto;
-import com.vk.sdk.api.model.VKAttachments;
 import com.vk.sdk.api.model.VKPhotoArray;
-import com.vk.sdk.api.model.VKWallPostResult;
 import com.vk.sdk.api.photo.VKUploadImage;
-import com.vk.sdk.api.photo.VKUploadWallPhotoRequest;
-import com.vk.sdk.util.VKStringJoiner;
-import com.vk.sdk.util.VKUtil;
-
-import java.util.ArrayList;
 
 /**
  * Share dialog for making post directly to VK.
@@ -80,14 +35,14 @@ import java.util.ArrayList;
  * <pre>
  * {@code VKPhotoArray photos = new VKPhotoArray();
  * photos.add(new VKApiPhoto("photo-47200925_314622346"));
- * new VKShareDialog()
+ * new VKShareDialogCompat()
  * .setText("I created this post with VK Android SDK\nSee additional information below\n#vksdk")
  * .setUploadedPhotos(photos)
  * .setAttachmentImages(new VKUploadImage[]{
  * new VKUploadImage(myBitmap, VKImageParameters.pngImage())
  * })
  * .setAttachmentLink("VK Android SDK information", "https://vk.com/dev/android_sdk")
- * .setShareDialogListener(new VKShareDialog.VKShareDialogListener() {
+ * .setShareDialogListener(new VKShareDialogCompat.VKShareDialogListener() {
  * public void onVkShareComplete(int postId) {
  *
  * }
@@ -99,395 +54,55 @@ import java.util.ArrayList;
  * }
  * </pre>
  */
-public class VKShareDialog extends DialogFragment {
-    static private final String SHARE_TEXT_KEY = "ShareText";
-    static private final String SHARE_LINK_KEY = "ShareLink";
-    static private final String SHARE_IMAGES_KEY = "ShareImages";
-    static private final String SHARE_UPLOADED_IMAGES_KEY = "ShareUploadedImages";
+public class VKShareDialog {
 
-    static private final int SHARE_PHOTO_HEIGHT = 100;
-    static private final int SHARE_PHOTO_CORNER_RADIUS = 3;
-    static private final int SHARE_PHOTO_MARGIN_LEFT = 10;
+    private VKShareDialogHelper.VKShareDialogApis mDialog;
 
-    private EditText mShareTextField;
-    private Button mSendButton;
-    private ProgressBar mSendProgress;
-    private LinearLayout mPhotoLayout;
-    private HorizontalScrollView mPhotoScroll;
+    public VKShareDialog() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            mDialog = new VKShareDialogICS();
+        } else {
+            mDialog = new VKShareDialogCompat();
+        }
+    }
 
-    private UploadingLink mAttachmentLink;
-    private VKUploadImage[] mAttachmentImages;
-    private VKPhotoArray mExistingPhotos;
-    private CharSequence mAttachmentText;
-
-    private VKShareDialogListener mListener;
-
-
-    /**
-     * Sets images that will be uploaded with post
-     *
-     * @param images array of VKUploadImage objects with image data and upload parameters
-     * @return Returns this dialog for chaining
-     */
-    public VKShareDialog setAttachmentImages(VKUploadImage[] images) {
-        mAttachmentImages = images;
+    public VKShareDialog setText(String text) {
+        mDialog.getHelper().setText(text);
         return this;
     }
 
-    /**
-     * Sets this dialog post text. User can change that text
-     *
-     * @param textToPost Text for post
-     * @return Returns this dialog for chaining
-     */
-    public VKShareDialog setText(CharSequence textToPost) {
-        mAttachmentText = textToPost;
-        return this;
-    }
-
-    /**
-     * Sets dialog link with link name
-     *
-     * @param linkTitle A small description for your link
-     * @param linkUrl   Url that link follows
-     * @return Returns this dialog for chaining
-     */
-    public VKShareDialog setAttachmentLink(String linkTitle, String linkUrl) {
-        mAttachmentLink = new UploadingLink(linkTitle, linkUrl);
-        return this;
-    }
-
-    /**
-     * Sets array of already uploaded photos from VK, that will be attached to post
-     *
-     * @param photos Prepared array of {@link VKApiPhoto} objects
-     * @return Returns this dialog for chaining
-     */
     public VKShareDialog setUploadedPhotos(VKPhotoArray photos) {
-        mExistingPhotos = photos;
+        mDialog.getHelper().setUploadedPhotos(photos);
+        return this;
+    }
+
+    public VKShareDialog setAttachmentImages(VKUploadImage[] vkUploadImages) {
+        mDialog.getHelper().setAttachmentImages(vkUploadImages);
+        return this;
+    }
+
+    public VKShareDialog setAttachmentLink(String s, String s1) {
+        mDialog.getHelper().setAttachmentLink(s, s1);
         return this;
     }
 
     /**
      * Sets this dialog listener
      *
-     * @param listener {@link VKShareDialogListener} object
+     * @param listener {@link VKShareDialog.VKShareDialogListener} object
      * @return Returns this dialog for chaining
      */
     public VKShareDialog setShareDialogListener(VKShareDialogListener listener) {
-        mListener = listener;
+        mDialog.getHelper().setShareDialogListener(listener);
         return this;
     }
 
-    @NonNull
-    @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Context context = getActivity();
-        View mInternalView = View.inflate(context, R.layout.vk_share_dialog, null);
-
-        assert mInternalView != null;
-
-        mSendButton = (Button) mInternalView.findViewById(R.id.sendButton);
-        mSendProgress = (ProgressBar) mInternalView.findViewById(R.id.sendProgress);
-        mPhotoLayout = (LinearLayout) mInternalView.findViewById(R.id.imagesContainer);
-        mShareTextField = (EditText) mInternalView.findViewById(R.id.shareText);
-        mPhotoScroll = (HorizontalScrollView) mInternalView.findViewById(R.id.imagesScrollView);
-
-        LinearLayout mAttachmentLinkLayout = (LinearLayout) mInternalView.findViewById(R.id.attachmentLinkLayout);
-
-        mSendButton.setOnClickListener(sendButtonPress);
-
-        //Attachment text
-        if (savedInstanceState != null) {
-            mShareTextField.setText(savedInstanceState.getString(SHARE_TEXT_KEY));
-            mAttachmentLink = savedInstanceState.getParcelable(SHARE_LINK_KEY);
-            mAttachmentImages = (VKUploadImage[]) savedInstanceState.getParcelableArray(SHARE_IMAGES_KEY);
-            mExistingPhotos = savedInstanceState.getParcelable(SHARE_UPLOADED_IMAGES_KEY);
-        } else if (mAttachmentText != null) {
-            mShareTextField.setText(mAttachmentText);
-        }
-
-        //Attachment photos
-        mPhotoLayout.removeAllViews();
-        if (mAttachmentImages != null) {
-            for (VKUploadImage mAttachmentImage : mAttachmentImages) {
-                addBitmapToPreview(mAttachmentImage.mImageData);
-            }
-            mPhotoLayout.setVisibility(View.VISIBLE);
-        }
-
-        if (mExistingPhotos != null) {
-            processExistingPhotos();
-        }
-        if (mExistingPhotos == null && mAttachmentImages == null) {
-            mPhotoLayout.setVisibility(View.GONE);
-        }
-
-        //Attachment link
-        if (mAttachmentLink != null) {
-            TextView linkTitle = (TextView) mAttachmentLinkLayout.findViewById(R.id.linkTitle),
-                    linkHost = (TextView) mAttachmentLinkLayout.findViewById(R.id.linkHost);
-
-            linkTitle.setText(mAttachmentLink.linkTitle);
-            linkHost.setText(VKUtil.getHost(mAttachmentLink.linkUrl));
-            mAttachmentLinkLayout.setVisibility(View.VISIBLE);
-        } else {
-            mAttachmentLinkLayout.setVisibility(View.GONE);
-        }
-        Dialog result = new Dialog(context);
-        result.requestWindowFeature(Window.FEATURE_NO_TITLE);
-        result.setContentView(mInternalView);
-        result.setCancelable(true);
-        result.setOnCancelListener(new DialogInterface.OnCancelListener() {
-            @Override
-            public void onCancel(DialogInterface dialogInterface) {
-                if (mListener != null) {
-                    mListener.onVkShareCancel();
-                }
-                dismissAllowingStateLoss();
-            }
-        });
-
-
-        return result;
+    public void show(android.app.FragmentManager fragmentManager, String vk_share_dialog) {
+        mDialog.show(fragmentManager, vk_share_dialog);
     }
 
-
-    @Override
-    @SuppressLint("NewApi")
-    public void onStart() {
-        super.onStart();
-
-        int width = WindowManager.LayoutParams.WRAP_CONTENT;
-
-        if (Build.VERSION.SDK_INT >= 13) {
-            WindowManager wm = (WindowManager) getActivity().getSystemService(Context.WINDOW_SERVICE);
-            Display display = wm.getDefaultDisplay();
-            Point size = new Point();
-            display.getSize(size);
-            width = size.x - getResources().getDimensionPixelSize(R.dimen.vk_share_dialog_view_padding) * 2;
-        }
-
-        WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
-        lp.copyFrom(getDialog().getWindow().getAttributes());
-        lp.height = WindowManager.LayoutParams.WRAP_CONTENT;
-        lp.width = width;
-        getDialog().getWindow().setAttributes(lp);
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString(SHARE_TEXT_KEY, mShareTextField.getText().toString());
-        if (mAttachmentLink != null)
-            outState.putParcelable(SHARE_LINK_KEY, mAttachmentLink);
-        if (mAttachmentImages != null)
-            outState.putParcelableArray(SHARE_IMAGES_KEY, mAttachmentImages);
-        if (mExistingPhotos != null)
-            outState.putParcelable(SHARE_UPLOADED_IMAGES_KEY, mExistingPhotos);
-    }
-
-    private void setIsLoading(boolean loading) {
-        if (loading) {
-            mSendButton.setVisibility(View.GONE);
-            mSendProgress.setVisibility(View.VISIBLE);
-            mShareTextField.setEnabled(false);
-            mPhotoLayout.setEnabled(false);
-        } else {
-            mSendButton.setVisibility(View.VISIBLE);
-            mSendProgress.setVisibility(View.GONE);
-            mShareTextField.setEnabled(true);
-            mPhotoLayout.setEnabled(true);
-        }
-    }
-
-    private void processExistingPhotos() {
-        ArrayList<String> photosToLoad = new ArrayList<>(mExistingPhotos.size());
-        for (VKApiPhoto photo : mExistingPhotos) {
-            photosToLoad.add("" + photo.owner_id + '_' + photo.id);
-        }
-        VKRequest photosById = new VKRequest("photos.getById",
-                VKParameters.from(VKApiConst.PHOTO_SIZES, 1, VKApiConst.PHOTOS, VKStringJoiner.join(photosToLoad, ",")), VKPhotoArray.class);
-        photosById.executeWithListener(new VKRequest.VKRequestListener() {
-            @Override
-            public void onComplete(VKResponse response) {
-                VKPhotoArray photos = (VKPhotoArray) response.parsedModel;
-                for (VKApiPhoto photo : photos) {
-                    if (photo.src.getByType('q') != null) {
-                        loadAndAddPhoto(photo.src.getByType('q'));
-                    } else if (photo.src.getByType('p') != null) {
-                        loadAndAddPhoto(photo.src.getByType('p'));
-                    } else if (photo.src.getByType('m') != null) {
-                        loadAndAddPhoto(photo.src.getByType('m'));
-                    }
-                    //else ignore that strange photo
-                }
-            }
-
-            @Override
-            public void onError(VKError error) {
-                if (VKSdk.DEBUG) {
-                    Log.w(VKSdk.SDK_TAG, "Cannot load photos for share: " + error.toString());
-                }
-                if (mListener != null) {
-                    mListener.onVkShareError(error);
-                }
-            }
-        });
-    }
-
-    private void loadAndAddPhoto(final String photoUrl) {
-        loadAndAddPhoto(photoUrl, 0);
-    }
-
-    private void loadAndAddPhoto(final String photoUrl, final int attempt) {
-        if (attempt > 10) return;
-        VKImageOperation op = new VKImageOperation(photoUrl);
-        op.setImageOperationListener(new VKImageOperation.VKImageOperationListener() {
-            @Override
-            public void onComplete(VKImageOperation operation, Bitmap image) {
-                if (image == null) {
-                    new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            loadAndAddPhoto(photoUrl, attempt + 1);
-                        }
-                    }, 1000);
-                    return;
-                }
-                addBitmapToPreview(image);
-            }
-
-            @Override
-            public void onError(VKImageOperation operation, VKError error) {
-                // todo method body
-            }
-        });
-        VKHttpClient.enqueueOperation(op);
-    }
-
-    private void addBitmapToPreview(Bitmap sourceBitmap) {
-        if (getActivity() == null) return;
-        Bitmap b = VKUIHelper.getRoundedCornerBitmap(sourceBitmap, SHARE_PHOTO_HEIGHT, SHARE_PHOTO_CORNER_RADIUS);
-        if (b == null) return;
-        ImageView iv = new ImageView(getActivity());
-        iv.setImageBitmap(b);
-        iv.setAdjustViewBounds(true);
-
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        params.setMargins(mPhotoLayout.getChildCount() > 0 ? SHARE_PHOTO_MARGIN_LEFT : 0, 0, 0, 0);
-
-        mPhotoLayout.addView(iv, params);
-        mPhotoLayout.invalidate();
-        mPhotoScroll.invalidate();
-    }
-
-    private void makePostWithAttachments(VKAttachments attachments) {
-
-        if (attachments == null) {
-            attachments = new VKAttachments();
-        }
-        if (mExistingPhotos != null) {
-            attachments.addAll(mExistingPhotos);
-        }
-        if (mAttachmentLink != null) {
-            attachments.add(new VKApiLink(mAttachmentLink.linkUrl));
-        }
-        String message = mShareTextField.getText().toString();
-
-        final Long userId = Long.parseLong(VKSdk.getAccessToken().userId);
-        VKRequest wallPost = VKApi.wall().post(VKParameters.from(VKApiConst.OWNER_ID, userId, VKApiConst.MESSAGE, message, VKApiConst.ATTACHMENTS, attachments.toAttachmentsString()));
-        wallPost.executeWithListener(new VKRequest.VKRequestListener() {
-            @Override
-            public void onError(VKError error) {
-                setIsLoading(false);
-                if (mListener != null) {
-                    mListener.onVkShareError(error);
-                }
-            }
-
-            @Override
-            public void onComplete(VKResponse response) {
-                setIsLoading(false);
-                VKWallPostResult res = (VKWallPostResult) response.parsedModel;
-                if (mListener != null) {
-                    mListener.onVkShareComplete(res.post_id);
-                }
-                dismissAllowingStateLoss();
-            }
-        });
-    }
-
-    View.OnClickListener sendButtonPress = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            setIsLoading(true);
-            if (mAttachmentImages != null && VKSdk.getAccessToken() != null) {
-                final Long userId = Long.parseLong(VKSdk.getAccessToken().userId);
-                VKUploadWallPhotoRequest photoRequest = new VKUploadWallPhotoRequest(mAttachmentImages, userId, 0);
-                photoRequest.executeWithListener(new VKRequest.VKRequestListener() {
-                    @Override
-                    public void onComplete(VKResponse response) {
-                        VKPhotoArray photos = (VKPhotoArray) response.parsedModel;
-                        VKAttachments attachments = new VKAttachments(photos);
-                        makePostWithAttachments(attachments);
-                    }
-
-                    @Override
-                    public void onError(VKError error) {
-                        setIsLoading(false);
-                        if (mListener != null) {
-                            mListener.onVkShareError(error);
-                        }
-                    }
-                });
-            } else {
-                makePostWithAttachments(null);
-            }
-        }
-    };
-
-    @Override
-    public void onCancel(DialogInterface dialog) {
-        super.onCancel(dialog);
-        if (mListener != null) {
-            mListener.onVkShareCancel();
-        }
-    }
-
-    static private class UploadingLink implements Parcelable {
-        public String linkTitle, linkUrl;
-
-        public UploadingLink(String title, String url) {
-            linkTitle = title;
-            linkUrl = url;
-        }
-
-        @Override
-        public int describeContents() {
-            return 0;
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            dest.writeString(this.linkTitle);
-            dest.writeString(this.linkUrl);
-        }
-
-        private UploadingLink(Parcel in) {
-            this.linkTitle = in.readString();
-            this.linkUrl = in.readString();
-        }
-
-        public static final Parcelable.Creator<UploadingLink> CREATOR = new Parcelable.Creator<UploadingLink>() {
-            public UploadingLink createFromParcel(Parcel source) {
-                return new UploadingLink(source);
-            }
-
-            public UploadingLink[] newArray(int size) {
-                return new UploadingLink[size];
-            }
-        };
+    public void show(android.support.v4.app.FragmentManager fragmentManager, String vk_share_dialog) {
+        mDialog.show(fragmentManager, vk_share_dialog);
     }
 
     public interface VKShareDialogListener {
@@ -497,4 +112,5 @@ public class VKShareDialog extends DialogFragment {
 
         void onVkShareError(VKError error);
     }
+
 }

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogCompat.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogCompat.java
@@ -1,0 +1,87 @@
+//
+//  Copyright (c) 2015 VK.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+package com.vk.sdk.dialogs;
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+
+public class VKShareDialogCompat extends DialogFragment implements VKShareDialogHelper.VKShareDialogApis {
+
+    private VKShareDialogHelper mHelper;
+
+    public VKShareDialogCompat() {
+        mHelper = new VKShareDialogHelper(this);
+    }
+
+    @Override
+    public void show(android.app.FragmentManager fragmentManager, String vk_share_dialog) {
+        throw new IllegalArgumentException("Please, use getFragmentManager() and not getSupportFragmentManager()");
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return mHelper.onCreateDialog(savedInstanceState);
+    }
+
+    @Override
+    @SuppressLint("NewApi")
+    public void onStart() {
+        super.onStart();
+        mHelper.onStart();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mHelper.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        mHelper.onCancel();
+
+    }
+
+    @Override
+    public Context onRequestActivity() {
+        return getActivity();
+    }
+
+    @Override
+    public void onRequestDismiss() {
+        dismissAllowingStateLoss();
+    }
+
+    @Override
+    public VKShareDialogHelper getHelper() {
+        return mHelper;
+    }
+
+}

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogHelper.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogHelper.java
@@ -1,0 +1,456 @@
+//
+//  Copyright (c) 2015 VK.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+package com.vk.sdk.dialogs;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.util.Log;
+import android.view.Display;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.HorizontalScrollView;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.vk.sdk.R;
+import com.vk.sdk.VKSdk;
+import com.vk.sdk.VKUIHelper;
+import com.vk.sdk.api.VKApi;
+import com.vk.sdk.api.VKApiConst;
+import com.vk.sdk.api.VKError;
+import com.vk.sdk.api.VKParameters;
+import com.vk.sdk.api.VKRequest;
+import com.vk.sdk.api.VKResponse;
+import com.vk.sdk.api.httpClient.VKHttpClient;
+import com.vk.sdk.api.httpClient.VKImageOperation;
+import com.vk.sdk.api.model.VKApiLink;
+import com.vk.sdk.api.model.VKApiPhoto;
+import com.vk.sdk.api.model.VKAttachments;
+import com.vk.sdk.api.model.VKPhotoArray;
+import com.vk.sdk.api.model.VKWallPostResult;
+import com.vk.sdk.api.photo.VKUploadImage;
+import com.vk.sdk.api.photo.VKUploadWallPhotoRequest;
+import com.vk.sdk.util.VKStringJoiner;
+import com.vk.sdk.util.VKUtil;
+
+import java.util.ArrayList;
+
+public class VKShareDialogHelper {
+
+    public interface VKShareDialogApis {
+
+        Context onRequestActivity();
+
+        void onRequestDismiss();
+
+        VKShareDialogHelper getHelper();
+
+        void show(android.app.FragmentManager fragmentManager, String vk_share_dialog);
+
+        void show(android.support.v4.app.FragmentManager fragmentManager, String vk_share_dialog);
+    }
+
+    static private final int SHARE_PHOTO_HEIGHT = 100;
+    static private final int SHARE_PHOTO_CORNER_RADIUS = 3;
+    static private final int SHARE_PHOTO_MARGIN_LEFT = 10;
+
+    static private final String SHARE_TEXT_KEY = "ShareText";
+    static private final String SHARE_LINK_KEY = "ShareLink";
+    static private final String SHARE_IMAGES_KEY = "ShareImages";
+    static private final String SHARE_UPLOADED_IMAGES_KEY = "ShareUploadedImages";
+    private View mInternalView;
+    private VKShareDialog.VKShareDialogListener mListener;
+    private final VKShareDialogApis mCallback;
+
+    private EditText mShareTextField;
+    private Button mSendButton;
+    private ProgressBar mSendProgress;
+    private LinearLayout mPhotoLayout;
+    private HorizontalScrollView mPhotoScroll;
+
+    private UploadingLink mAttachmentLink;
+    private VKUploadImage[] mAttachmentImages;
+    private VKPhotoArray mExistingPhotos;
+    private CharSequence mAttachmentText;
+    private Dialog mDialog;
+
+    public VKShareDialogHelper(VKShareDialogApis vkShareDialog) {
+        this.mCallback = vkShareDialog;
+    }
+
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        mInternalView = View.inflate(mCallback.onRequestActivity(), R.layout.vk_share_dialog, null);
+
+        assert mInternalView != null;
+
+        mSendButton = (Button) mInternalView.findViewById(R.id.sendButton);
+        mSendProgress = (ProgressBar) mInternalView.findViewById(R.id.sendProgress);
+        mPhotoLayout = (LinearLayout) mInternalView.findViewById(R.id.imagesContainer);
+        mShareTextField = (EditText) mInternalView.findViewById(R.id.shareText);
+        mPhotoScroll = (HorizontalScrollView) mInternalView.findViewById(R.id.imagesScrollView);
+
+        LinearLayout mAttachmentLinkLayout = (LinearLayout) mInternalView.findViewById(R.id.attachmentLinkLayout);
+
+        mSendButton.setOnClickListener(sendButtonPress);
+
+        //Attachment text
+        if (savedInstanceState != null) {
+            mShareTextField.setText(savedInstanceState.getString(SHARE_TEXT_KEY));
+            mAttachmentLink = savedInstanceState.getParcelable(SHARE_LINK_KEY);
+            mAttachmentImages = (VKUploadImage[]) savedInstanceState.getParcelableArray(SHARE_IMAGES_KEY);
+            mExistingPhotos = savedInstanceState.getParcelable(SHARE_UPLOADED_IMAGES_KEY);
+        } else if (mAttachmentText != null) {
+            mShareTextField.setText(mAttachmentText);
+        }
+
+        //Attachment photos
+        mPhotoLayout.removeAllViews();
+        if (mAttachmentImages != null) {
+            for (VKUploadImage mAttachmentImage : mAttachmentImages) {
+                addBitmapToPreview(mAttachmentImage.mImageData);
+            }
+            mPhotoLayout.setVisibility(View.VISIBLE);
+        }
+
+        if (mExistingPhotos != null) {
+            processExistingPhotos();
+        }
+        if (mExistingPhotos == null && mAttachmentImages == null) {
+            mPhotoLayout.setVisibility(View.GONE);
+        }
+
+        //Attachment link
+        if (mAttachmentLink != null) {
+            TextView linkTitle = (TextView) mAttachmentLinkLayout.findViewById(R.id.linkTitle),
+                    linkHost = (TextView) mAttachmentLinkLayout.findViewById(R.id.linkHost);
+
+            linkTitle.setText(mAttachmentLink.linkTitle);
+            linkHost.setText(VKUtil.getHost(mAttachmentLink.linkUrl));
+            mAttachmentLinkLayout.setVisibility(View.VISIBLE);
+        } else {
+            mAttachmentLinkLayout.setVisibility(View.GONE);
+        }
+
+        mDialog = new Dialog(mCallback.onRequestActivity());
+        mDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        mDialog.setContentView(mInternalView);
+        mDialog.setCancelable(true);
+
+        return mDialog;
+    }
+
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putString(SHARE_TEXT_KEY, mShareTextField.getText().toString());
+        if (mAttachmentLink != null)
+            outState.putParcelable(SHARE_LINK_KEY, mAttachmentLink);
+        if (mAttachmentImages != null)
+            outState.putParcelableArray(SHARE_IMAGES_KEY, mAttachmentImages);
+        if (mExistingPhotos != null)
+            outState.putParcelable(SHARE_UPLOADED_IMAGES_KEY, mExistingPhotos);
+    }
+
+    public void setShareDialogListener(VKShareDialog.VKShareDialogListener listener) {
+        mListener = listener;
+    }
+
+    /**
+     * Sets images that will be uploaded with post
+     *
+     * @param images array of VKUploadImage objects with image data and upload parameters
+     * @return Returns this mDialog for chaining
+     */
+    public VKShareDialogHelper setAttachmentImages(VKUploadImage[] images) {
+        mAttachmentImages = images;
+        return this;
+    }
+
+    /**
+     * Sets this mDialog post text. User can change that text
+     *
+     * @param textToPost Text for post
+     * @return Returns this mDialog for chaining
+     */
+    public VKShareDialogHelper setText(CharSequence textToPost) {
+        mAttachmentText = textToPost;
+        return this;
+    }
+
+    /**
+     * Sets mDialog link with link name
+     *
+     * @param linkTitle A small description for your link
+     * @param linkUrl   Url that link follows
+     * @return Returns this mDialog for chaining
+     */
+    public VKShareDialogHelper setAttachmentLink(String linkTitle, String linkUrl) {
+        mAttachmentLink = new UploadingLink(linkTitle, linkUrl);
+        return this;
+    }
+
+    /**
+     * Sets array of already uploaded photos from VK, that will be attached to post
+     *
+     * @param photos Prepared array of {@link VKApiPhoto} objects
+     * @return Returns this mDialog for chaining
+     */
+    public VKShareDialogHelper setUploadedPhotos(VKPhotoArray photos) {
+        mExistingPhotos = photos;
+        return this;
+    }
+
+    private void setIsLoading(boolean loading) {
+        if (loading) {
+            mSendButton.setVisibility(View.GONE);
+            mSendProgress.setVisibility(View.VISIBLE);
+            mShareTextField.setEnabled(false);
+            mPhotoLayout.setEnabled(false);
+        } else {
+            mSendButton.setVisibility(View.VISIBLE);
+            mSendProgress.setVisibility(View.GONE);
+            mShareTextField.setEnabled(true);
+            mPhotoLayout.setEnabled(true);
+        }
+    }
+
+    private void processExistingPhotos() {
+        ArrayList<String> photosToLoad = new ArrayList<>(mExistingPhotos.size());
+        for (VKApiPhoto photo : mExistingPhotos) {
+            photosToLoad.add("" + photo.owner_id + '_' + photo.id);
+        }
+        VKRequest photosById = new VKRequest("photos.getById",
+                VKParameters.from(VKApiConst.PHOTO_SIZES, 1, VKApiConst.PHOTOS, VKStringJoiner.join(photosToLoad, ",")), VKPhotoArray.class);
+        photosById.executeWithListener(new VKRequest.VKRequestListener() {
+            @Override
+            public void onComplete(VKResponse response) {
+                VKPhotoArray photos = (VKPhotoArray) response.parsedModel;
+                for (VKApiPhoto photo : photos) {
+                    if (photo.src.getByType('q') != null) {
+                        loadAndAddPhoto(photo.src.getByType('q'));
+                    } else if (photo.src.getByType('p') != null) {
+                        loadAndAddPhoto(photo.src.getByType('p'));
+                    } else if (photo.src.getByType('m') != null) {
+                        loadAndAddPhoto(photo.src.getByType('m'));
+                    }
+                    //else ignore that strange photo
+                }
+            }
+
+            @Override
+            public void onError(VKError error) {
+                if (VKSdk.DEBUG) {
+                    Log.w(VKSdk.SDK_TAG, "Cannot load photos for share: " + error.toString());
+                }
+                if (mListener != null) {
+                    mListener.onVkShareError(error);
+                }
+            }
+        });
+    }
+
+    private void loadAndAddPhoto(final String photoUrl, final int attempt) {
+        if (attempt > 10) return;
+        VKImageOperation op = new VKImageOperation(photoUrl);
+        op.setImageOperationListener(new VKImageOperation.VKImageOperationListener() {
+            @Override
+            public void onComplete(VKImageOperation operation, Bitmap image) {
+                if (image == null) {
+                    new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            loadAndAddPhoto(photoUrl, attempt + 1);
+                        }
+                    }, 1000);
+                    return;
+                }
+                addBitmapToPreview(image);
+            }
+
+            @Override
+            public void onError(VKImageOperation operation, VKError error) {
+                // todo method body
+            }
+        });
+        VKHttpClient.enqueueOperation(op);
+    }
+
+    private void loadAndAddPhoto(final String photoUrl) {
+        loadAndAddPhoto(photoUrl, 0);
+    }
+
+    private void addBitmapToPreview(Bitmap sourceBitmap) {
+        if (mCallback.onRequestActivity() == null) return;
+        Bitmap b = VKUIHelper.getRoundedCornerBitmap(sourceBitmap, SHARE_PHOTO_HEIGHT, SHARE_PHOTO_CORNER_RADIUS);
+        if (b == null) return;
+        ImageView iv = new ImageView(mCallback.onRequestActivity());
+        iv.setImageBitmap(b);
+        iv.setAdjustViewBounds(true);
+
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        params.setMargins(mPhotoLayout.getChildCount() > 0 ? SHARE_PHOTO_MARGIN_LEFT : 0, 0, 0, 0);
+
+        mPhotoLayout.addView(iv, params);
+        mPhotoLayout.invalidate();
+        mPhotoScroll.invalidate();
+    }
+
+    public void onStart() {
+        int width = WindowManager.LayoutParams.WRAP_CONTENT;
+
+        if (Build.VERSION.SDK_INT >= 13) {
+            WindowManager wm = (WindowManager) mCallback.onRequestActivity().getSystemService(Context.WINDOW_SERVICE);
+            Display display = wm.getDefaultDisplay();
+            Point size = new Point();
+            display.getSize(size);
+            width = size.x - mCallback.onRequestActivity().getResources().getDimensionPixelSize(R.dimen.vk_share_dialog_view_padding) * 2;
+        }
+
+        WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+        lp.copyFrom(mDialog.getWindow().getAttributes());
+        lp.height = WindowManager.LayoutParams.WRAP_CONTENT;
+        lp.width = width;
+        mDialog.getWindow().setAttributes(lp);
+
+    }
+
+    public void onCancel() {
+        if (mListener != null) {
+            mListener.onVkShareCancel();
+        }
+    }
+
+    static private class UploadingLink implements Parcelable {
+        public String linkTitle, linkUrl;
+
+        public UploadingLink(String title, String url) {
+            linkTitle = title;
+            linkUrl = url;
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            dest.writeString(this.linkTitle);
+            dest.writeString(this.linkUrl);
+        }
+
+        private UploadingLink(Parcel in) {
+            this.linkTitle = in.readString();
+            this.linkUrl = in.readString();
+        }
+
+        public static final Parcelable.Creator<UploadingLink> CREATOR = new Parcelable.Creator<UploadingLink>() {
+            public UploadingLink createFromParcel(Parcel source) {
+                return new UploadingLink(source);
+            }
+
+            public UploadingLink[] newArray(int size) {
+                return new UploadingLink[size];
+            }
+        };
+    }
+
+    private void makePostWithAttachments(VKAttachments attachments) {
+
+        if (attachments == null) {
+            attachments = new VKAttachments();
+        }
+        if (mExistingPhotos != null) {
+            attachments.addAll(mExistingPhotos);
+        }
+        if (mAttachmentLink != null) {
+            attachments.add(new VKApiLink(mAttachmentLink.linkUrl));
+        }
+        String message = mShareTextField.getText().toString();
+
+        final Long userId = Long.parseLong(VKSdk.getAccessToken().userId);
+        VKRequest wallPost = VKApi.wall().post(VKParameters.from(VKApiConst.OWNER_ID, userId, VKApiConst.MESSAGE, message, VKApiConst.ATTACHMENTS, attachments.toAttachmentsString()));
+        wallPost.executeWithListener(new VKRequest.VKRequestListener() {
+            @Override
+            public void onError(VKError error) {
+                setIsLoading(false);
+                if (mListener != null) {
+                    mListener.onVkShareError(error);
+                }
+            }
+
+            @Override
+            public void onComplete(VKResponse response) {
+                setIsLoading(false);
+                VKWallPostResult res = (VKWallPostResult) response.parsedModel;
+                if (mListener != null) {
+                    mListener.onVkShareComplete(res.post_id);
+                }
+                mCallback.onRequestDismiss();
+            }
+        });
+    }
+
+    View.OnClickListener sendButtonPress = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            setIsLoading(true);
+            if (mAttachmentImages != null && VKSdk.getAccessToken() != null) {
+                final Long userId = Long.parseLong(VKSdk.getAccessToken().userId);
+                VKUploadWallPhotoRequest photoRequest = new VKUploadWallPhotoRequest(mAttachmentImages, userId, 0);
+                photoRequest.executeWithListener(new VKRequest.VKRequestListener() {
+                    @Override
+                    public void onComplete(VKResponse response) {
+                        VKPhotoArray photos = (VKPhotoArray) response.parsedModel;
+                        VKAttachments attachments = new VKAttachments(photos);
+                        makePostWithAttachments(attachments);
+                    }
+
+                    @Override
+                    public void onError(VKError error) {
+                        setIsLoading(false);
+                        if (mListener != null) {
+                            mListener.onVkShareError(error);
+                        }
+                    }
+                });
+            } else {
+                makePostWithAttachments(null);
+            }
+        }
+    };
+}

--- a/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogICS.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/dialogs/VKShareDialogICS.java
@@ -1,0 +1,86 @@
+//
+//  Copyright (c) 2014 VK.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+package com.vk.sdk.dialogs;
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.app.DialogFragment;
+
+@SuppressLint("NewApi")
+public class VKShareDialogICS extends DialogFragment implements VKShareDialogHelper.VKShareDialogApis {
+
+    private VKShareDialogHelper mHelper;
+
+    public VKShareDialogICS() {
+        mHelper = new VKShareDialogHelper(this);
+    }
+
+    @Override
+    public void show(android.support.v4.app.FragmentManager fragmentManager, String vk_share_dialog) {
+        throw new IllegalArgumentException("Please, use getSupportFragmentManager() and not getFragmentManager()");
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return mHelper.onCreateDialog(savedInstanceState);
+    }
+
+    @Override
+    @SuppressLint("NewApi")
+    public void onStart() {
+        super.onStart();
+        mHelper.onStart();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mHelper.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        mHelper.onCancel();
+    }
+
+    @Override
+    public Context onRequestActivity() {
+        return getActivity();
+    }
+
+    @Override
+    public void onRequestDismiss() {
+        dismissAllowingStateLoss();
+    }
+
+    @Override
+    public VKShareDialogHelper getHelper() {
+        return mHelper;
+    }
+
+}

--- a/vksdk_library/src/main/res/layout-v17/vk_share_dialog.xml
+++ b/vksdk_library/src/main/res/layout-v17/vk_share_dialog.xml
@@ -7,7 +7,7 @@
     android:layout_gravity="center"
     android:orientation="vertical"
 
-    tools:context="com.vk.sdk.dialogs.VKShareDialog">
+    tools:context=".dialogs.VKShareDialogCompat">
     <View
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/vksdk_library/src/main/res/layout/vk_share_dialog.xml
+++ b/vksdk_library/src/main/res/layout/vk_share_dialog.xml
@@ -6,7 +6,7 @@
     android:layout_centerInParent="true"
     android:layout_gravity="center"
     android:orientation="vertical"
-    tools:context="com.vk.sdk.dialogs.VKShareDialog"
+    tools:context=".dialogs.VKShareDialogCompat"
     tools:ignore="RtlHardcoded">
     <View
         android:layout_width="0dp"


### PR DESCRIPTION
Currently, VKShare dialog requires support Fragment manager and does not work with native ICS Fragments.

This patch makes the VKShare dialog work with native ICS activities as well. 

Depending on the Android version we now create the "Share" dialog as either a native or a support DialogFragment.  The created fragment then delegates the functionality (which is common in both cases) to the helper class. The helper is, essentially, doing what VKShareDialog class did before, removing the unecessary dependency on the support library.

Test application has been modified to create either a support or a native ICS fragment TestActivity.

Any feedback is welcome.

