### PR TITLE
Fix unnecessary parameter annotation

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/VKSdk.java
@@ -255,7 +255,7 @@ public class VKSdk {
         VKServiceActivity.startLoginActivity(fragment, requestedPermissions = preparingScopeList(scope));
     }
 
-    public static boolean onActivityResult(int requestCode, int resultCode, @NonNull Intent data, @NonNull VKCallback<VKAccessToken> vkCallback) {
+    public static boolean onActivityResult(int requestCode, int resultCode, Intent data, @NonNull VKCallback<VKAccessToken> vkCallback) {
         if (requestCode == VKServiceActivity.VKServiceType.Authorization.getOuterCode()) {
             if (resultCode == VKSdk.RESULT_OK) {
                 vkCallback.onResult(VKAccessToken.currentToken());


### PR DESCRIPTION
`data `object will be null if authorization request succeeds, `@NonNull` annotation cause the inability to use the method from Kotlin due to Null safety check.