### PR TITLE
Исправление VKApiPhotoAlbum

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/api/model/VKApiPhotoAlbum.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/api/model/VKApiPhotoAlbum.java
@@ -109,10 +109,12 @@ public class VKApiPhotoAlbum extends VKAttachments.VKApiAttachment implements Pa
      */
     public VKPhotoSizes photo = new VKPhotoSizes();
 
-	public VKApiPhotoAlbum(JSONObject from) throws JSONException
-	{
-		parse(from);
-	}
+    public VKApiPhoto thumb = new VKApiPhoto();
+
+    public VKApiPhotoAlbum(JSONObject from) throws JSONException
+    {
+        parse(from);
+    }
     /**
      * Creates a PhotoAlbum instance from JSONObject.
      */
@@ -141,6 +143,10 @@ public class VKApiPhotoAlbum extends VKAttachments.VKApiAttachment implements Pa
             photo.add(VKApiPhotoSize.create(COVER_X, 432, 249));
             photo.sort();
         }
+        JSONObject thumb_obj = from.optJSONObject("thumb");
+        if(thumb_obj != null) {
+            this.thumb = new VKApiPhoto().parse(thumb_obj);
+        }
         return this;
     }
 
@@ -160,6 +166,7 @@ public class VKApiPhotoAlbum extends VKAttachments.VKApiAttachment implements Pa
         this.thumb_id = in.readInt();
         this.thumb_src = in.readString();
         this.photo = in.readParcelable(VKPhotoSizes.class.getClassLoader());
+        this.thumb = in.readParcelable(VKApiPhoto.class.getClassLoader());
     }
 
     /**
@@ -212,6 +219,7 @@ public class VKApiPhotoAlbum extends VKAttachments.VKApiAttachment implements Pa
         dest.writeInt(this.thumb_id);
         dest.writeString(this.thumb_src);
         dest.writeParcelable(this.photo, flags);
+        dest.writeParcelable(this.thumb, flags);
     }
 
     public static Creator<VKApiPhotoAlbum> CREATOR = new Creator<VKApiPhotoAlbum>() {


### PR DESCRIPTION
Обложка альбома (thumb) возвращается как объект типа photo. 
https://new.vk.com/dev/attachments_w?f=12.%20%D0%90%D0%BB%D1%8C%D0%B1%D0%BE%D0%BC%20%D1%81%20%D1%84%D0%BE%D1%82%D0%BE%D0%B3%D1%80%D0%B0%D1%84%D0%B8%D1%8F%D0%BC%D0%B8%20(type%3Dalbum)
