### PR TITLE
Call error handlers when batch request was canceled.

### DIFF
--- a/vksdk_library/src/main/java/com/vk/sdk/api/VKBatchRequest.java
+++ b/vksdk_library/src/main/java/com/vk/sdk/api/VKBatchRequest.java
@@ -35,6 +35,7 @@ public class VKBatchRequest extends VKObject {
     private final VKResponse[] mResponses;
     private final VKRequest.VKRequestListener[] mOriginalListeners;
     private boolean mCanceled = false;
+    private boolean mErrorOccured = false;
 
     /**
      * Specify listener for current request
@@ -129,8 +130,8 @@ public class VKBatchRequest extends VKObject {
     }
 
     protected void provideError(VKError error) {
-        if (mCanceled)
-            return;
+        if (mErrorOccured) return;
+        mErrorOccured = true;
         for (int i = 0; i < mRequests.length; i++) {
             VKRequest.VKRequestListener l = mOriginalListeners[i];
             if (l != null) {


### PR DESCRIPTION
Исходя из документации, при вызове VKRequest.cancel() должен вызываться errorBlock с соответствующей ошибкой, но в случае группирования нескольких VKRequest в VKBatchRequest и вызове VKBatchRequest.cancel() это не работает, errorBlock ни самого VKBatchRequest, ни вложенных VKRequest не вызывается. Предлагаемый патч исправляет эту проблему.