### PR TITLE
Fix bug in VK's webview with infinity progress bar

### DIFF
--- a/vk-sdk-core/src/main/java/com/vk/api/sdk/ui/VKWebViewAuthActivity.kt
+++ b/vk-sdk-core/src/main/java/com/vk/api/sdk/ui/VKWebViewAuthActivity.kt
@@ -81,6 +81,7 @@ open class VKWebViewAuthActivity: Activity() {
             isVerticalScrollBarEnabled = false
             visibility = View.INVISIBLE
             overScrollMode = View.OVER_SCROLL_NEVER
+            resumeTimers()
         }
         webView.settings.apply {
             javaScriptEnabled = true


### PR DESCRIPTION
Fix bug in cases when we have some independent WebViews and one of them calls pauseTimers(). In this case, vk's WebView onPageFinished() method is not being called and we have an infinity progress bar.

Починен баг, в котором при некоторых условиях при попытке авторизации крутился бесконечно прогресс бар.
Условия:
Активити с WebView, с нее открываем авторизацию через VK.login. Приложение VK не установлено на устройстве.
В активити в onPause вызывается webview.pauseTiners. Эта функция глобально паузит все webview и при попытке oauth авторизации метод onPageFinished у webview  VKWebViewAuthActivity никогда не вызовется. Воспроизводится на API 21+